### PR TITLE
chore: upgrade analyzer to v7 and source_gen to v2

### DIFF
--- a/packages/flutterfire_gen/pubspec.yaml
+++ b/packages/flutterfire_gen/pubspec.yaml
@@ -4,12 +4,13 @@ version: 0.5.0
 homepage: https://github.com/kosukesaigusa/flutterfire_gen
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=5.13.0 <7.0.0"
+  analyzer: ^7.3.0
   build: ^2.4.1
   cloud_firestore: ^5.5.0
+  dart_style: ^3.0.0
   flutter:
     sdk: flutter
   flutterfire_gen_annotation: ^0.4.1
@@ -17,7 +18,7 @@ dependencies:
   json_annotation: ^4.8.1
   meta: ^1.9.1
   path: ^1.8.3
-  source_gen: ^1.5.0
+  source_gen: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.4.7

--- a/packages/flutterfire_gen/pubspec_overrides.yaml
+++ b/packages/flutterfire_gen/pubspec_overrides.yaml
@@ -7,7 +7,6 @@ dependency_overrides:
 
   # pub downgrade:
   # flutterfire_gen generated codes includes sealed class feature to be formatted
-  dart_style: ^2.3.0
   # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
   # flutterfire_gen requires file: ^6.1.3
   file: ^6.1.3


### PR DESCRIPTION
## Summary
This PR updates flutterfire_gen to support newer analyzer and source_gen versions,
restoring compatibility with modern Flutter/Dart toolchains.

Closes #76 

## Motivation
While upgrading a Flutter project to a newer Flutter version (3.38.5),
dependency resolution issues were encountered when using flutterfire_gen
together with modern code generators such as freezed >=2.5.8.

These generators require `source_gen ^2.0.0`,
which is incompatible with the current analyzer/source_gen constraints
in flutterfire_gen.

## Changes
- Upgrade `analyzer` to `^7.3.0`
- Upgrade `source_gen` to `^2.0.0`
- Update `dart_style` to a compatible version

## Breaking change
This change may affect users using older Flutter/Dart SDKs
due to updated analyzer/source_gen constraints.

## Verification
- flutter pub get
- dart run build_runner build
- Example project build
